### PR TITLE
Encapsulate the dictionary transformation into `get_gc_metrics_numbers_for_jupyter`

### DIFF
--- a/src/benchmarks/gc/docs/bench_file.md
+++ b/src/benchmarks/gc/docs/bench_file.md
@@ -7,8 +7,7 @@ Each is a map with keys being arbitrary names.
 Here's an example benchfile:
 
 ```yaml
-test_executables:
-  defgcperfsim: /performance/artifacts/bin/GCPerfSim/release/netcoreapp5.0/GCPerfSim.dll
+test_executables: {}
 coreclrs:
   clr_a:
     core_root: coreclr
@@ -58,12 +57,11 @@ benchmarks:
 comment: `str | None`
   (ignored)
 
-vary: `"machine" | "executable" | "coreclr" | "config" | "benchmark" | None`
+vary: `"machine" | "coreclr" | "config" | "benchmark" | "executable" | None`
   Preferred property to vary when using `py . diff`
 
 test_executables: `Mapping[str, Path]`
-  Mapping from an (arbitrary) executable name to its path.
-  Paths to the dll's that will be run with the Core_Root.
+  Mapping of dll's to run when issuing `py . run` or `py . suite-run`
 
 configs_vary_by: `[ConfigsVaryBy](#ConfigsVaryBy) | None`
   This is mostly set just for information.

--- a/src/benchmarks/gc/jupyter_notebook.py
+++ b/src/benchmarks/gc/jupyter_notebook.py
@@ -692,37 +692,7 @@ metrics_data = get_gc_metrics_numbers_for_jupyter(
     machines=None,
 )
 
-# %% Import pandas and read the array created in the previous cell, into a
-# pandas Data Frame.
-# This imports are not done before because the file where the array is stored
-# is only created in the previous cell.
-
-# This loop only searches for the metrics currently found in the data set and
-# stores them for lookup later. The reason we use a dictionary is because we
-# require to preserve order and Python does not natively have Ordered Sets.
-
-metric_names_found = {}
-for test_iteration in metrics_data:
-    for metric_key in test_iteration:
-        metric_names_found[metric_key] = True
-
-# This is the main loop. It creates the dictionary with the information
-# that pandas is expecting. It iterates the set of metrics retrieved in the
-# previous loop, and gets the numbers from each iteration of the test.
-# In the end, this dictionary is composed by:
-# Keys: Metric Names
-# Values: List with said metric's values from each run
-
-data_dict = {}
-for metric_name in metric_names_found:
-    metric_values = []
-
-    for test_iteration in metrics_data:
-        value = test_iteration[metric_name]
-        metric_values.append(value)
-    data_dict[metric_name] = metric_values
-
-data_frame = pandas.DataFrame.from_dict(data_dict)
+data_frame = pandas.DataFrame.from_dict(metrics_data)
 
 # %% Do pandas numbers analysis here.
 

--- a/src/benchmarks/gc/jupyter_notebook.py
+++ b/src/benchmarks/gc/jupyter_notebook.py
@@ -703,4 +703,8 @@ data_frame.describe()
 heap_sizes = data_frame[["HeapSizeBeforeMB_Mean", "HeapSizeAfterMB_Mean"]]
 heap_sizes.plot()
 
+# %% Obtain the statistics grouped by config and benchmark
+
+data_frame.groupby(["config_name","benchmark_name"]).mean()
+
 # %%

--- a/src/benchmarks/gc/src/analysis/report.py
+++ b/src/benchmarks/gc/src/analysis/report.py
@@ -886,6 +886,8 @@ def get_gc_metrics_numbers_for_jupyter(
             # which has to be unwrapped.
             iter_ok_result: MetricValuesForSingleIteration = unwrap(iteration)
             data_map: Dict[str, float] = {}
+            data_map["config_name"] = t.config_name
+            data_map["benchmark_name"] = t.benchmark_name
 
             for iter_key, iter_value in iter_ok_result.items():
                 # iter_key = RunMetric, iter_value = FailableValue(Union(bool, int, float))


### PR DESCRIPTION
This can simplify the Jupyter notebook, the notebook user don't need to know how to do the conversion.